### PR TITLE
Rename Design Automation to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Design Automation for Inventor - Utility Library
+# Inventor Automation API Utility Library
 
 ![Platforms](https://img.shields.io/badge/Platform-Windows-lightgrey.svg)
 ![.NET](https://img.shields.io/badge/.NET%20Standard-2.0-blue.svg)
@@ -8,15 +8,13 @@
 ![Platforms](https://img.shields.io/badge/Design%20Automation-v3-green.svg)
 ![Platforms](https://img.shields.io/badge/Inventor-grey.svg)
 
-This is package helps leverage Inventor plugin code for Design Automation. The compiled version is available on [Nuget](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation.Inventor.Utils). 
+This is package helps leverage Inventor plugin code for the Automation Service. The compiled version is available on [Nuget](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation.Inventor.Utils).
 
 ## Usage
 
-This package is used by the [Design Automation for Inventor](https://marketplace.visualstudio.com/items?itemName=Autodesk.DesignAutomation) Visual Studio template. 
+This package is used by the [Inventor Automation API template](https://marketplace.visualstudio.com/items?itemName=Autodesk.DesignAutomation2) Visual Studio template.
 
 ## Documentation
-
-Please refer to [this sample](https://github.com/Developer-Autodesk/design.automation.inventor-csharp-basics) for more information. 
 
 #### HeartBeat class
 
@@ -46,4 +44,4 @@ This library is licensed under the terms of the [MIT License](http://opensource.
 
 ## Written by
 
-David Obergries, [Forge Partner Development](http://forge.autodesk.com)
+David Obergries, [APS Partner Development](https://aps.autodesk.com/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![.NET](https://img.shields.io/badge/.NET%20Standard-2.0-blue.svg)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
-![Platforms](https://img.shields.io/badge/Design%20Automation-v3-green.svg)
+![Platforms](https://img.shields.io/badge/Automation%20API-v3-green.svg)
 ![Platforms](https://img.shields.io/badge/Inventor-grey.svg)
 
 This is package helps leverage Inventor plugin code for the Automation Service. The compiled version is available on [Nuget](https://www.nuget.org/packages/Autodesk.Forge.DesignAutomation.Inventor.Utils).

--- a/Solution/DesignAutomationInventorUtilities Tests/Helpers/NameValueMapHelperTests.cs
+++ b/Solution/DesignAutomationInventorUtilities Tests/Helpers/NameValueMapHelperTests.cs
@@ -1,6 +1,6 @@
 ﻿/////////////////////////////////////////////////////////////////////
 // Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
+// Written by APS Partner Development
 //
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,

--- a/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
+++ b/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Autodesk.Forge.DesignAutomation.Inventor.Utils</AssemblyName>
     <RootNamespace>Autodesk.Forge.DesignAutomation.Inventor.Utils</RootNamespace>
     <PackageId>Autodesk.Forge.DesignAutomation.Inventor.Utils</PackageId>
-    <Authors>Inventor Automation team</Authors>
+    <Authors>Inventor Automation Team</Authors>
     <Company>Autodesk</Company>
     <PackageTags>invio</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
+++ b/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Autodesk.Forge.DesignAutomation.Inventor.Utils</AssemblyName>
     <RootNamespace>Autodesk.Forge.DesignAutomation.Inventor.Utils</RootNamespace>
     <PackageId>Autodesk.Forge.DesignAutomation.Inventor.Utils</PackageId>
-    <Authors>Design Automation Team</Authors>
+    <Authors>Inventor Automation Team</Authors>
     <Company>Autodesk</Company>
     <PackageTags>invio</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
+++ b/Solution/DesignAutomationInventorUtilities/DesignAutomationInventorUtilities.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Autodesk.Forge.DesignAutomation.Inventor.Utils</AssemblyName>
     <RootNamespace>Autodesk.Forge.DesignAutomation.Inventor.Utils</RootNamespace>
     <PackageId>Autodesk.Forge.DesignAutomation.Inventor.Utils</PackageId>
-    <Authors>Inventor Automation Team</Authors>
+    <Authors>Inventor Automation team</Authors>
     <Company>Autodesk</Company>
     <PackageTags>invio</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Solution/DesignAutomationInventorUtilities/Extensions/NameValueMapExtension.cs
+++ b/Solution/DesignAutomationInventorUtilities/Extensions/NameValueMapExtension.cs
@@ -1,6 +1,6 @@
 ﻿/////////////////////////////////////////////////////////////////////
 // Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
+// Written by APS Partner Development
 //
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,

--- a/Solution/DesignAutomationInventorUtilities/HeartBeat.cs
+++ b/Solution/DesignAutomationInventorUtilities/HeartBeat.cs
@@ -1,6 +1,6 @@
 ﻿/////////////////////////////////////////////////////////////////////
 // Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
+// Written by APS Partner Development
 //
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,

--- a/Solution/DesignAutomationInventorUtilities/OnDemand.cs
+++ b/Solution/DesignAutomationInventorUtilities/OnDemand.cs
@@ -1,6 +1,6 @@
 ﻿/////////////////////////////////////////////////////////////////////
 // Copyright (c) Autodesk, Inc. All rights reserved
-// Written by Forge Partner Development
+// Written by APS Partner Development
 //
 // Permission to use, copy, modify, and distribute this software in
 // object code form for any purpose and without fee is hereby granted,

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,6 +1,6 @@
 
 
-# design.automation.inventor-utilities
+# inventor.automation.api-utilities
 
 # 2.0.1
 * fixed HeartBeat issue with .net8.


### PR DESCRIPTION
- Rename Design Automation to Automation
- Update links to point to Autodesk.DesignAutomation2